### PR TITLE
Development

### DIFF
--- a/bot/app/config.py
+++ b/bot/app/config.py
@@ -8,7 +8,7 @@ from datetime import time
 
 from telegram import User
 
-PARTICIPANT_LIST_OPENING = time(0)
+PARTICIPANT_LIST_OPENING = time(7)
 PARTICIPATION_LIST_REMINDER = time(19)
 REPORT_WINDOW_OPENING = time(0)
 PARTICIPANTS_LIST_CLOSURE = time(hour=21, minute=45)

--- a/bot/app/main.py
+++ b/bot/app/main.py
@@ -689,7 +689,7 @@ async def send_participants_list(context: ContextTypes.DEFAULT_TYPE) -> None:
         sqla_session.close()
         return
 
-    if not (rnd := category.first_non_completed_round()):
+    if not (rnd := category.next_round()):
         sqla_session.close()
         return
 

--- a/models.py
+++ b/models.py
@@ -1487,8 +1487,8 @@ class RaceResult(Base):
     relative_position: Mapped[int] = mapped_column(SmallInteger)
     fastest_lap: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     participated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    gap_to_first: Mapped[Decimal | None] = mapped_column(Numeric(precision=3))
-    total_racetime: Mapped[Decimal | None] = mapped_column(Numeric(precision=3))
+    gap_to_first: Mapped[Decimal | None] = mapped_column(Numeric(precision=8, scale=3))
+    total_racetime: Mapped[Decimal | None] = mapped_column(Numeric(precision=8, scale=3))
 
     driver_id: Mapped[int] = mapped_column(
         ForeignKey("drivers.driver_id"), nullable=False

--- a/models.py
+++ b/models.py
@@ -1488,7 +1488,9 @@ class RaceResult(Base):
     fastest_lap: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     participated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     gap_to_first: Mapped[Decimal | None] = mapped_column(Numeric(precision=8, scale=3))
-    total_racetime: Mapped[Decimal | None] = mapped_column(Numeric(precision=8, scale=3))
+    total_racetime: Mapped[Decimal | None] = mapped_column(
+        Numeric(precision=8, scale=3)
+    )
 
     driver_id: Mapped[int] = mapped_column(
         ForeignKey("drivers.driver_id"), nullable=False


### PR DESCRIPTION
- Fix wrong precision and scale values in models file
- Use calendar instead of last completed round for deciding which round's participation list to display. This is because the last completed round depends on the admins updating the results in time for the first race of the following week, if the results aren't updated, the bot didn't send the list because it couldn't save the new round_participants records.
- Change the time the participation list is sent to 7 AM.